### PR TITLE
Evolve extend feed

### DIFF
--- a/feed.php
+++ b/feed.php
@@ -86,6 +86,7 @@ function slugify($text)
 
 /**
  *  Merge multidemensionnal array by value on each row
+ *  https://stackoverflow.com/questions/7973915/php-merge-arrays-by-value
  */
 function array_merge_callback($array1, $array2, $predicate)
 {
@@ -211,6 +212,20 @@ if($cfg_product_features){
 }
 
 
+/*
+ * Extend doofinder feed
+ *
+ * To add an new header, module can do an array_merge on $extra_header
+ * To add an new data to a product, module must create a multidemensionnal array as this :
+ * array(
+ *   index => array(
+ *    'id_product' => value,
+ *    'new_header_column_name' => 'value related to the new column'
+ *   ),
+ *   [...]
+ * )
+ * As each module can extend $extra_header and $extra_rows don't forget to merge them
+ */
 $extra_header = array();
 $extra_row = array();
 Hook::exec('actionDoofinderExtendFeed', array(

--- a/feed.php
+++ b/feed.php
@@ -88,16 +88,33 @@ function slugify($text)
  *  Merge multidemensionnal array by value on each row
  *  https://stackoverflow.com/questions/7973915/php-merge-arrays-by-value
  */
-function array_merge_callback($array1, $array2, $predicate)
+function array_merge_by_id_product($array1 = array(), $array2 = array())
 {
+    $sub_key = 'id_product';
     $result = array();
+    $result_row = array();
+
+    if (empty($array1)) {
+      return $array2;
+    }
+    if (empty($array2)) {
+      return $array1;
+    }
 
     foreach ($array1 as $item1) {
-        foreach ($array2 as $item2) {
-            if ($predicate($item1, $item2)) {
-                $result[] = array_merge($item1, $item2);
+        $result_row = array();
+        //Merge data
+        foreach ($array2 as $key => $item2) {
+            if($item1[$sub_key] == $item2[$sub_key]) {
+              $result_row = array_merge($item1, $item2);
+              break;
             }
         }
+        //If no array merged
+        if (empty($result_row)) {
+            $result_row = $item1;
+        }
+        $result[] = $result_row;
     }
 
     return $result;
@@ -250,9 +267,7 @@ if (!$limit || ($offset !== false && intval($offset) === 0))
 // PRODUCTS
 $rows = dfTools::getAvailableProductsForLanguage($lang->id, $shop->id, $limit, $offset);
 if (!empty($extra_rows)) {
-    $rows = array_merge_callback($rows, $extra_rows, function ($item1, $item2) {
-        return (int)$item1['id_product'] == (int)$item2['id_product'];
-    });
+    $rows = array_merge_by_id_product($rows, $extra_rows);
 }
 
 foreach ($rows as $row) {
@@ -437,7 +452,7 @@ foreach ($rows as $row) {
 
     foreach ($extra_header as $extra) {
         echo TXT_SEPARATOR;
-        echo $row[$extra];
+        echo isset($row[$extra]) ? $row[$extra] : "";
     }
 
     echo PHP_EOL;


### PR DESCRIPTION
Solve #44 

Allow external module to extend feed data. New data must set in `$params['extra_header]` and `$params['extra_rows']`
As sample add df_rating value.

```
    public function hookactionDoofinderExtendFeed($params)
    {
        //extra_row
        $df_rating_name = "df_rating";
        $extra_rows = array();
        //Merge new header column
        $params['extra_header'] = array_merge($params['extra_header'], array($df_rating_name));

        $query = new DbQuery();
        $query->select('id_product')
                ->from('product')
                ->where('active = 1')
                ->where('visibility IN ("search", "both")')
                ->orderBy('id_product')
                ->limit($params['limit'], $params['offset']);
        $rows = Db::getInstance()->executeS($query);

        foreach ($rows as $key => $row) {
            $rating = MyModule::getRating(
                array(
                  'id_product' => $row['id_product'],
                )
            );
            $extra_rows[] = array(
                'id_product' => $row['id_product'],
                $df_rating_name => $rating['average'] ? $rating['average'] : ""
            );
        }
    }
    $params['extra_rows'] = array_merge_by_id_product($params['extra_rows'], $extra_rows);
```

